### PR TITLE
Adjustments to backend controller endpoints

### DIFF
--- a/src/main/java/com/revature/controllers/ProductController.java
+++ b/src/main/java/com/revature/controllers/ProductController.java
@@ -44,7 +44,7 @@ public class ProductController {
     }
 
     @Authorized
-    @PostMapping("/{id}")
+    @PutMapping("/{id}") // PUT - Updates a product by ID
     public ResponseEntity<Product> updateProduct(@PathVariable("id") int id, @RequestBody Product product, HttpSession httpsession){
         User u=(User) httpsession.getAttribute("user");
         Optional<Product> p= productService.findById(id);
@@ -60,7 +60,7 @@ public class ProductController {
     }
 
     @Authorized
-    @PutMapping
+    @PostMapping // POST - Creates a new product
     public ResponseEntity<Product> upsert(@RequestBody Product product, HttpSession session) {
         User u= (User) session.getAttribute("user");
         if(u.getRole().toString()=="Admin") {
@@ -72,17 +72,6 @@ public class ProductController {
         }
         else{
             return ResponseEntity.notFound().build();
-        }
-    }
-    @Authorized
-    @PostMapping
-    public ResponseEntity<String> update(@RequestBody Product product, HttpSession session) {
-        User u= (User) session.getAttribute("user");
-        if(u.getRole().toString()=="Admin") {
-            return ResponseEntity.ok(productService.update(product));
-        }
-        else{
-            return ResponseEntity.ok("Must be logged in as Admin to perform this action");
         }
     }
 
@@ -130,7 +119,7 @@ public class ProductController {
         return ResponseEntity.ok("Product is deleted");
     }
     @Authorized
-    @PutMapping("/featured/{id}")
+    @PutMapping("/featured/{id}") // Updates product status to be featured - by product ID
     public ResponseEntity<String> addFeaturedProduct(@PathVariable("id") int id, HttpSession session) {
         User u= (User) session.getAttribute("user");
         if(u.getRole().toString()=="Admin") {
@@ -141,7 +130,7 @@ public class ProductController {
         }
     }
     @Authorized
-    @DeleteMapping("/featured/{id}")
+    @DeleteMapping("/featured/{id}") // Updates product status to be NOT featured - by product ID
     public ResponseEntity<String> deleteFeaturedProduct(@PathVariable("id") int id, HttpSession session) {
         User u= (User) session.getAttribute("user");
         if(u.getRole().toString()=="Admin") {
@@ -179,7 +168,7 @@ public class ProductController {
     }
 
     @Authorized
-    @GetMapping("/overZero")
+    @GetMapping("/stocked") // Returns products that are currently in stock (quantity over zero)
     public ResponseEntity<List<Product>> getProductsOverZero() {
         return ResponseEntity.ok(productService.getProductsOverZero());
     }

--- a/src/test/java/com/revature/ECommerceApplicationTests.java
+++ b/src/test/java/com/revature/ECommerceApplicationTests.java
@@ -28,7 +28,6 @@ import io.restassured.response.Response;
 // https://www.baeldung.com/karate-rest-api-testing
 
 
-
 // APPLICATION TESTS (aka controller tests)
 // These tests should only check if the controller endpoints return an OK response (for now)
 


### PR DESCRIPTION
- There is now only one update product and one create product endpoint:
    - Create product: (POST) "api/product"          [ needs a json object with everything but the product ID ]
    - Update product: (PUT) "api/product/{id}"    [ needs a json object with everything but the product ID ]
- "api/product/overZero " is now "api/product/stocked" - the endpoint that returns list of items with quantity over zero
